### PR TITLE
Fix encodeFor methods with null string parameter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,11 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
     secrets: inherit
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
 
   # Format PR
   format_check:

--- a/src/main/java/ortus/boxlang/modules/esapi/bifs/EncodeForUnits.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/bifs/EncodeForUnits.java
@@ -62,11 +62,16 @@ public class EncodeForUnits extends BIF {
 	 */
 	public String _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		Key		bifMethodKey	= arguments.getAsKey( BIF.__functionName );
-		String	str				= arguments.getAsString( Key.string ).trim();
+		String	str				= arguments.getAsString( Key.string );
 		boolean	canonicalize	= arguments.getAsBoolean( Key.canonicalize );
 
+		if ( str == null ) {
+			return null;
+		}
+		str = str.trim();
+
 		// Get the ESAPI encoder
-		Encoder	encoder			= ESAPI.encoder();
+		Encoder encoder = ESAPI.encoder();
 
 		// Canonicalize the input string if requested
 		if ( canonicalize ) {

--- a/src/test/java/ortus/boxlang/modules/esapi/bifs/ESAPITest.java
+++ b/src/test/java/ortus/boxlang/modules/esapi/bifs/ESAPITest.java
@@ -14,6 +14,7 @@
  */
 package ortus.boxlang.modules.esapi.bifs;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -65,6 +66,13 @@ public class ESAPITest {
 	public void testEncodeForHTML() {
 		instance.executeSource( "result = encodeForHTML( '<test>', false )", context );
 		assertEquals( "&lt;test&gt;", variables.get( result ) );
+	}
+
+	@DisplayName( "EncodeForX methods return nulls unmodified" )
+	@Test
+	public void testEncodeForHTMLWithNull() {
+		instance.executeSource( "result = encodeForHTML( null )", context );
+		assertNull( variables.get( result ) );
 	}
 
 	@DisplayName( "It can encode for HTML attribute" )


### PR DESCRIPTION
# Description

Fixes `EncodeFor*()` methods when the incoming `string` parameter is `null`.

## Jira/Github Issues

[All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

BoxLang Jira: https://ortussolutions.atlassian.net/browse/BL/issues
Module Issues: https://github.com/boxlang-modules/bx-esapi/issues](https://ortussolutions.atlassian.net/browse/BL-170)

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
