### PR TITLE
GetSafeHTML - Add optional maxInputSize argument to override the defa…

### DIFF
--- a/src/main/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTML.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTML.java
@@ -28,6 +28,8 @@ import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
 import ortus.boxlang.runtime.types.BoxLangType;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 @BoxBIF
@@ -42,7 +44,7 @@ public class GetSafeHTML extends BIF {
 		declaredArguments = new Argument[] {
 		    new Argument( true, Argument.STRING, Key.string ),
 		    new Argument( false, Argument.STRING, KeyDirectory.policy, "" ),
-		    new Argument( false, Argument.INTEGER, KeyDirectory.maxInputSize, 0 )
+		    new Argument( false, Argument.STRUCT, KeyDirectory.directives, new Struct() )
 		};
 	}
 
@@ -68,7 +70,7 @@ public class GetSafeHTML extends BIF {
 	 *
 	 * @arguments.policy The policy to use for sanitization
 	 *
-	 * @arguments.maxInputSize Maximum number of characters to accept (0 = use policy default of 20,000)
+	 * @arguments.directives Optional struct of AntiSamy directive overrides (e.g. { maxInputSize: 100000, nofollowAnchors: true })
 	 *
 	 * @return The sanitized HTML
 	 */
@@ -88,10 +90,10 @@ public class GetSafeHTML extends BIF {
 
 		try {
 			// Scan the input and get clean results
-			Policy	loadedPolicy	= AntiSamyUtil.loadPolicy( policy );
-			int		maxInput		= arguments.getAsInteger( KeyDirectory.maxInputSize );
-			if ( maxInput > 0 ) {
-				loadedPolicy = AntiSamyUtil.withMaxInputSize( loadedPolicy, maxInput );
+			Policy	loadedPolicy		= AntiSamyUtil.loadPolicy( policy );
+			IStruct	directiveOverrides	= ( IStruct ) arguments.get( KeyDirectory.directives );
+			if ( !directiveOverrides.isEmpty() ) {
+				loadedPolicy = AntiSamyUtil.withDirectives( loadedPolicy, directiveOverrides );
 			}
 			CleanResults results = new AntiSamy().scan( input, loadedPolicy );
 			return results.getCleanHTML();

--- a/src/main/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTML.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTML.java
@@ -16,6 +16,7 @@ package ortus.boxlang.modules.esapi.bifs;
 
 import org.owasp.validator.html.AntiSamy;
 import org.owasp.validator.html.CleanResults;
+import org.owasp.validator.html.Policy;
 
 import ortus.boxlang.modules.esapi.util.AntiSamyUtil;
 import ortus.boxlang.modules.esapi.util.KeyDirectory;
@@ -40,7 +41,8 @@ public class GetSafeHTML extends BIF {
 		super();
 		declaredArguments = new Argument[] {
 		    new Argument( true, Argument.STRING, Key.string ),
-		    new Argument( false, Argument.STRING, KeyDirectory.policy, "" )
+		    new Argument( false, Argument.STRING, KeyDirectory.policy, "" ),
+		    new Argument( false, Argument.INTEGER, KeyDirectory.maxInputSize, 0 )
 		};
 	}
 
@@ -66,6 +68,8 @@ public class GetSafeHTML extends BIF {
 	 *
 	 * @arguments.policy The policy to use for sanitization
 	 *
+	 * @arguments.maxInputSize Maximum number of characters to accept (0 = use policy default of 20,000)
+	 *
 	 * @return The sanitized HTML
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
@@ -84,7 +88,12 @@ public class GetSafeHTML extends BIF {
 
 		try {
 			// Scan the input and get clean results
-			CleanResults results = new AntiSamy().scan( input, AntiSamyUtil.loadPolicy( policy ) );
+			Policy	loadedPolicy	= AntiSamyUtil.loadPolicy( policy );
+			int		maxInput		= arguments.getAsInteger( KeyDirectory.maxInputSize );
+			if ( maxInput > 0 ) {
+				loadedPolicy = AntiSamyUtil.withMaxInputSize( loadedPolicy, maxInput );
+			}
+			CleanResults results = new AntiSamy().scan( input, loadedPolicy );
 			return results.getCleanHTML();
 		} catch ( Exception e ) {
 			// Handle exceptions (e.g., policy file not found, AntiSamy initialization error)

--- a/src/main/java/ortus/boxlang/modules/esapi/util/AntiSamyUtil.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/util/AntiSamyUtil.java
@@ -87,20 +87,22 @@ public class AntiSamyUtil {
 	}
 
 	/**
-	 * Returns a copy of the given policy with a custom maxInputSize directive.
+	 * Returns a copy of the given policy with directive overrides applied from a struct.
+	 * Keys must be the camelCase directive names used by AntiSamy (e.g. {@code maxInputSize},
+	 * {@code nofollowAnchors}, {@code preserveComments}).
 	 *
-	 * @param base         The base policy to copy
-	 * @param maxInputSize The maximum input size in characters
+	 * @param base      The base policy to copy
+	 * @param overrides A struct of directive key/value pairs to override
 	 *
-	 * @return A new policy with the overridden maxInputSize
+	 * @return A new policy with the overrides applied
 	 */
 	@SuppressWarnings( "unchecked" )
-	public static Policy withMaxInputSize( Policy base, int maxInputSize ) {
+	public static Policy withDirectives( Policy base, IStruct overrides ) {
 		try {
 			Field directivesField = Policy.class.getDeclaredField( "directives" );
 			directivesField.setAccessible( true );
 			Map<String, String> directives = new HashMap<>( ( Map<String, String> ) directivesField.get( base ) );
-			directives.put( Policy.MAX_INPUT_SIZE, String.valueOf( maxInputSize ) );
+			overrides.entrySet().forEach( entry -> directives.put( entry.getKey().getName(), entry.getValue().toString() ) );
 
 			Field tagRulesField = Policy.class.getDeclaredField( "tagRules" );
 			tagRulesField.setAccessible( true );
@@ -116,7 +118,7 @@ public class AntiSamyUtil {
 			    ( Map<String, Tag> ) tagRulesField.get( base ),
 			    ( Map<String, Property> ) cssRulesField.get( base ) );
 		} catch ( Exception e ) {
-			throw new BoxRuntimeException( "Error overriding maxInputSize on policy", e );
+			throw new BoxRuntimeException( "Error applying policy directive overrides", e );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/modules/esapi/util/AntiSamyUtil.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/util/AntiSamyUtil.java
@@ -15,9 +15,16 @@
 package ortus.boxlang.modules.esapi.util;
 
 import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.owasp.validator.html.InternalPolicy;
 import org.owasp.validator.html.Policy;
+import org.owasp.validator.html.model.Property;
+import org.owasp.validator.html.model.Tag;
 
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
@@ -76,6 +83,40 @@ public class AntiSamyUtil {
 			return Policy.getInstance( policy );
 		} catch ( Exception e ) {
 			throw new BoxRuntimeException( "Error loading policy [" + policy + "]", e );
+		}
+	}
+
+	/**
+	 * Returns a copy of the given policy with a custom maxInputSize directive.
+	 *
+	 * @param base         The base policy to copy
+	 * @param maxInputSize The maximum input size in characters
+	 *
+	 * @return A new policy with the overridden maxInputSize
+	 */
+	@SuppressWarnings( "unchecked" )
+	public static Policy withMaxInputSize( Policy base, int maxInputSize ) {
+		try {
+			Field directivesField = Policy.class.getDeclaredField( "directives" );
+			directivesField.setAccessible( true );
+			Map<String, String> directives = new HashMap<>( ( Map<String, String> ) directivesField.get( base ) );
+			directives.put( Policy.MAX_INPUT_SIZE, String.valueOf( maxInputSize ) );
+
+			Field tagRulesField = Policy.class.getDeclaredField( "tagRules" );
+			tagRulesField.setAccessible( true );
+
+			Field cssRulesField = Policy.class.getDeclaredField( "cssRules" );
+			cssRulesField.setAccessible( true );
+
+			Constructor<InternalPolicy> ctor = InternalPolicy.class.getDeclaredConstructor(
+			    Policy.class, Map.class, Map.class, Map.class );
+			ctor.setAccessible( true );
+			return ctor.newInstance( base,
+			    directives,
+			    ( Map<String, Tag> ) tagRulesField.get( base ),
+			    ( Map<String, Property> ) cssRulesField.get( base ) );
+		} catch ( Exception e ) {
+			throw new BoxRuntimeException( "Error overriding maxInputSize on policy", e );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/modules/esapi/util/KeyDirectory.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/util/KeyDirectory.java
@@ -41,6 +41,7 @@ public class KeyDirectory {
 	public static final Key	javascript				= Key.of( "javascript" );
 	public static final Key	json					= Key.of( "json" );
 	public static final Key	ldap					= Key.of( "ldap" );
+	public static final Key	maxInputSize			= Key.of( "maxInputSize" );
 	public static final Key	moduleName				= Key.of( "moduleName" );
 	public static final Key	mysql					= Key.of( "mysql" );
 	public static final Key	mysql_ansi				= Key.of( "mysql_ansi" );

--- a/src/main/java/ortus/boxlang/modules/esapi/util/KeyDirectory.java
+++ b/src/main/java/ortus/boxlang/modules/esapi/util/KeyDirectory.java
@@ -40,8 +40,8 @@ public class KeyDirectory {
 	public static final Key	htmlAttribute			= Key.of( "htmlAttribute" );
 	public static final Key	javascript				= Key.of( "javascript" );
 	public static final Key	json					= Key.of( "json" );
+	public static final Key	directives				= Key.of( "directives" );
 	public static final Key	ldap					= Key.of( "ldap" );
-	public static final Key	maxInputSize			= Key.of( "maxInputSize" );
 	public static final Key	moduleName				= Key.of( "moduleName" );
 	public static final Key	mysql					= Key.of( "mysql" );
 	public static final Key	mysql_ansi				= Key.of( "mysql_ansi" );

--- a/src/test/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTMLTest.java
+++ b/src/test/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTMLTest.java
@@ -35,23 +35,23 @@ public class GetSafeHTMLTest extends BaseIntegrationTest {
 		assertThat( variables.get( result ) ).isEqualTo( "" );
 	}
 
-	@DisplayName( "It respects a custom maxInputSize that exceeds the default 20k limit" )
+	@DisplayName( "It respects directive overrides passed as a struct" )
 	@Test
-	public void testGetSafeHTMLWithMaxInputSize() {
+	public void testGetSafeHTMLWithDirectives() {
 		// Build a safe HTML string just over the 20,000-character default
 		String largeInput = "<b>" + "a".repeat( 20_001 ) + "</b>";
 
-		// Without maxInputSize override it should throw
+		// Without directives override it should throw due to the default 20k limit
 		variables.put( Key.of( "input" ), largeInput );
 		assertThrows( BoxRuntimeException.class, () -> runtime.executeSource(
 		    "result = getSafeHTML( input );",
 		    context
 		) );
 
-		// With a large enough maxInputSize it should succeed
+		// With maxInputSize raised via a directives struct it should succeed
 		runtime.executeSource(
 		    """
-		    	result = getSafeHTML( input, "ebay", 100000 );
+		    	result = getSafeHTML( input, "ebay", { maxInputSize: 100000 } );
 		    """,
 		    context
 		);

--- a/src/test/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTMLTest.java
+++ b/src/test/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTMLTest.java
@@ -1,11 +1,14 @@
 package ortus.boxlang.modules.esapi.bifs;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.modules.esapi.BaseIntegrationTest;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 
 public class GetSafeHTMLTest extends BaseIntegrationTest {
 
@@ -30,6 +33,30 @@ public class GetSafeHTMLTest extends BaseIntegrationTest {
 		);
 
 		assertThat( variables.get( result ) ).isEqualTo( "" );
+	}
+
+	@DisplayName( "It respects a custom maxInputSize that exceeds the default 20k limit" )
+	@Test
+	public void testGetSafeHTMLWithMaxInputSize() {
+		// Build a safe HTML string just over the 20,000-character default
+		String largeInput = "<b>" + "a".repeat( 20_001 ) + "</b>";
+
+		// Without maxInputSize override it should throw
+		variables.put( Key.of( "input" ), largeInput );
+		assertThrows( BoxRuntimeException.class, () -> runtime.executeSource(
+		    "result = getSafeHTML( input );",
+		    context
+		) );
+
+		// With a large enough maxInputSize it should succeed
+		runtime.executeSource(
+		    """
+		    	result = getSafeHTML( input, "ebay", 100000 );
+		    """,
+		    context
+		);
+
+		assertThat( variables.getAsString( result ) ).contains( "a".repeat( 100 ) );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTMLTest.java
+++ b/src/test/java/ortus/boxlang/modules/esapi/bifs/GetSafeHTMLTest.java
@@ -56,7 +56,7 @@ public class GetSafeHTMLTest extends BaseIntegrationTest {
 		    context
 		);
 
-		assertThat( variables.getAsString( result ) ).contains( "a".repeat( 100 ) );
+		assertThat( variables.getAsString( result ) ).isEqualTo( largeInput );
 	}
 
 }


### PR DESCRIPTION
GetSafeHTML - Add optional maxInputSize argument to override the default 20k character limit

# Description

Allows third parameter `maxInputSize` into getSafeHTML() method to override the default 20k maxInputSize limit.

`getSafeHTML(input, "eBay", 30000)`



## Type of change

- [ X ] Improvement

## Checklist

- [ X] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
